### PR TITLE
update toolchain and workflow

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -8,8 +8,8 @@ pip3 install numpy
 export BUILD_DIR=$PWD
 export PATH=$PWD/riscv/bin:$PATH
 mkdir -p riscv && cd riscv
-wget https://github.com/stnolting/riscv-gcc-prebuilt/releases/download/rv32i-131023/riscv32-unknown-elf.gcc-13.2.0.tar.gz
-tar -xzvf riscv32-unknown-elf.gcc-13.2.0.tar.gz
+wget https://github.com/fedy0/riscvxx-unknown-elf-prebuilt/releases/latest/download/riscvxx-unknown-elf-prebuilt.tar.gz
+tar -xzvf riscvxx-unknown-elf-prebuilt.tar.gz
 
 cd ../SW/compiler
 make clean all
@@ -17,4 +17,4 @@ cd ../fs
 python3 bin2c.py
 cd ..
 make clean all -f makefile.kernels
-make clean all RISCV_PATH=$BUILD_DIR/riscv/ RISCV_NAME=riscv32-unknown-elf UNIT_TEST=yes
+make clean all RISCV_PATH=$BUILD_DIR/riscv/ RISCV_NAME=riscv64-unknown-elf UNIT_TEST=yes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,29 +1,22 @@
+name: Generate Toolchains
+
 on:
   push:
-    # Sequence of patterns matched against refs/tags
     tags:
-      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
-
-name: Create Release
-
+      - "*"
+  
 jobs:
+
   build:
-    name: Create Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+
+      - name: 'Add Release Note & Artifact'
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          body: |
-            Changes in this Release
-            - First Change
-            - Second Change
-          draft: false
-          prerelease: false
+          bodyFile: "CHANGELOG.md"           #artifacts: "Add path to release.tar.gz,foo/*.txt"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+All notable changes to this project is documented in this file.
+
+## ztachip v0.0.2
+### Changed
+ - Add CHANGELOG.md to track major changes in each release
+ - Workflow bugfix
+ - Add Verilog support


### PR DESCRIPTION
Update RISCV toolchain and release workflow

## Toolchain
Update RISCV toolchain to the latest prebuilt toolchain

## Workflow
To autogenerate a release, update the CHANGELOG.md file with the description of the latest updates then commit with
```bash
git add *
git commit -m"commit message"
git push
git tag <add release version>
git push --tags origin # OR  git push origin <add release version>
```

To add artifacts (e.g. a file generated during automated test) to the release, simply specify the path in `.github/workflows/release.yml` as 
```bash
      - name: 'Add Release Note & Artifact'
        uses: ncipollo/release-action@v1
        with:
          bodyFile: "CHANGELOG.md"
          artifacts: "Add path to artifacts eg. release.tar.gz, foo/*.txt"
```